### PR TITLE
Fix/migration ftth

### DIFF
--- a/src/telecom/pack/migration/pack-migration-process.service.js
+++ b/src/telecom/pack/migration/pack-migration-process.service.js
@@ -222,7 +222,7 @@ export default /* @ngInject */ function ($q, OvhApiPackXdsl, Poller) {
     migrationProcess.selectedOffer = offer;
     if (_.includes(migrationProcess.selectedOffer.offerName.toLowerCase(), 'ftth')) {
       // Check if the current offer is already FTTH
-      if (_.includes(migrationProcess.pack.description.toLowerCase(), 'ftth')) {
+      if (_.includes(migrationProcess.pack.offerDescription.toLowerCase(), 'ftth')) {
         migrationProcess.currentStep = 'serviceDelete';
       } else {
         migrationProcess.currentStep = 'buildingDetails';


### PR DESCRIPTION
For some clients, the field pack.description is empty and generate failure when they try to migrate to FTTH offer.

Ref: UXCT-16